### PR TITLE
Added functionality for doffs that can be slotted in ground and space…

### DIFF
--- a/main.py
+++ b/main.py
@@ -1033,6 +1033,17 @@ class SETS():
                         results.append(html[e])
         return [] if isinstance(results, int) else results
 
+    def searchJsonTableContains(self, html, field, phrases):
+        """Return Json table elements containing 1 or more phrases or partial phrases"""
+        results = []
+        for e in range(len(html)):
+            if field in html[e]:
+                for phrase in phrases:
+                    if html[e][field].find(phrase)!=-1:
+                        results.append(html[e])
+        return [] if isinstance(results, int) else results
+
+
     def precacheModifiers(self):
         """Fetch equipment modifiers"""
         if 'modifiers' in self.cache and self.cache['modifiers'] is not None and len(self.cache['modifiers']) > 0:
@@ -1111,7 +1122,7 @@ class SETS():
             return self.cache['doffs'][keyPhrase]
 
         phrases = [keyPhrase]
-        doffMatches = self.searchJsonTable(self.doffs, "shipdutytype", phrases)
+        doffMatches = self.searchJsonTableContains(self.doffs, "shipdutytype", phrases)
 
         self.cache['doffs'][keyPhrase] = {self.deWikify(doffMatches[item]['name'])+str(doffMatches[item]['powertype']): doffMatches[item] for item in range(len(doffMatches))}
         self.cache['doffNames'][keyPhrase] = {self.deWikify(doffMatches[item]['name']): '' for item in range(len(doffMatches))}


### PR DESCRIPTION
… (searchJsonTableContains)

Good day! To address the existence of doffs that can be slotted into either ground or space (and not just one or the other), we need to address both the source data (wiki) and the SETS code that processes it. 

The wiki's 'shipdutytype' field is a string and there are no built-in limitation on acceptable values. So, after confirming with the wiki folks, we should be able to simply change the value from "Space" _or_ "Ground", and replace it with both values: "Space, Ground", "Ground, Ship", or even just "Ground Space".

SETS currently only searches for an exact match in the 'shipdutytype' field (exactly matching "Space" or "Ground"). I created a copy of the existing searchJsonTable routine (which is utilized elsewhere and needs to remain). I named the new routine, searchJsonTableContains, and modified it to search for the existence of a phrase anywhere in the field's value. 

And finally, I changed the precacheDoffs function to call the new searchJsonTableContains code instead of the old. 