### PR TITLE
Improve PNG load performance

### DIFF
--- a/main.py
+++ b/main.py
@@ -437,12 +437,16 @@ class SETS():
             return
 
         total_pixels = array.size//n
-        hidden_bits = ""
+        hidden_bits = [""] * (total_pixels * 3)
+        counter = 0
+
         for p in range(total_pixels):
             if p % 5000 == 0:
                 self.progress_bar_update()
             for q in range(0, 3):
-                hidden_bits += (bin(array[p][q])[2:][-1])
+                hidden_bits[counter] = (bin(array[p][q])[2:][-1])
+                counter += 1
+        hidden_bits = "".join(hidden_bits)
         hidden_bits = [hidden_bits[i:i+8] for i in range(0, len(hidden_bits), 8)]
         message = ""
         for i in range(len(hidden_bits)):

--- a/main.py
+++ b/main.py
@@ -116,7 +116,7 @@ class SETS():
     # Current version encoding [this is not likely to be final, update for packaging]
     # year.month[release-type]day[0-9 for daily iteration]
     # 2023.4b10 = 2023, April, Beta, 1st [of april], 0 [first iteration of the day]
-    version = '2023.8b151'
+    version = '2023.8b300'
 
     daysDelayBeforeReattempt = 7
 


### PR DESCRIPTION
Improved loading from png file by initializing hidden_bits to its full size to avoid using += which is slow for a string list.

Performance improvement: 20 min load to 3 seconds 