### PR TITLE
fix: normalise legacy items missing mark/modifiers fields on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Builds can be exported to a PNG or JSON file that can be opened by another perso
 
 ## Installation
 ### Images library
-All installation methods require an images library containing the game icons. The app will download these automatically, but as this takes a very long time, it is recommended to download the newest compressed image library from the [release](https://github.com/STOCD/releases) page. Once downloaded this has to be decompressed and placed in into the `.config/images` folder.
+All installation methods require an images library containing the game icons. The app will download these automatically, but as this takes a very long time, it is recommended to download the newest compressed image library from the [release](https://github.com/STOCD/SETS/releases) page. Once downloaded this has to be decompressed and placed in into the `.config/images` folder.
 ```
 SETS
  +- .config
@@ -18,7 +18,7 @@ SETS
 ```
 
 ### Executable for Windows
-Download the zipped app from the [release](https://github.com/STOCD/releases) page. Unzip it into a folder where you want your app to live. To speed up the image downloading process, obtain the images library as detailed above. Double-clicking `SETS.exe` will start the app.
+Download the zipped app from the [release](https://github.com/STOCD/SETS/releases) page. Unzip it into a folder where you want your app to live. To speed up the image downloading process, obtain the images library as detailed above. Double-clicking `SETS.exe` will start the app.
 
 You can create a desktop shortcut by rightclicking on `SETS.exe` and clicking on "Create shortcut" in the context menu. Then move the created shortcut to your desktop. To create a start menu entry, open the start menu folder by rightclicking on an arbitrary app in your start menu and clicking on "Open file location". Then move the created shortcut to the folder that opened.
 

--- a/src/buildupdater.py
+++ b/src/buildupdater.py
@@ -409,6 +409,9 @@ def load_equipment_cat(self, build_key: str, environment: str):
     """
     for subkey, item in enumerate(self.build[environment][build_key]):
         if item is not None and item != '':
+            if isinstance(item, dict):
+                item.setdefault('mark', '')
+                item.setdefault('modifiers', [None, None, None, None])
             slot_equipment_item(self, item, environment, build_key, subkey)
         else:
             self.widgets.build[environment][build_key][subkey].clear()


### PR DESCRIPTION
Builds saved before the `mark`/`modifiers` fields were introduced crash when loaded because `slot_equipment_item` (via `add_equipment_tooltip_header`) expects these keys to be present.

Add `setdefault` guards in `load_equipment_cat` so old saves are silently upgraded on first load — no data is lost, the fields are initialised to their default empty values.