### PR TITLE
fix: Federation Intel Holoship missing extra Universal Console slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Builds can be exported to a PNG or JSON file that can be opened by another perso
 
 ## Installation
 ### Images library
-All installation methods require an images library containing the game icons. The app will download these automatically, but as this takes a very long time, it is recommended to download the newest compressed image library from the [release](https://github.com/STOCD/releases) page. Once downloaded this has to be decompressed and placed in into the `.config/images` folder.
+All installation methods require an images library containing the game icons. The app will download these automatically, but as this takes a very long time, it is recommended to download the newest compressed image library from the [release](https://github.com/STOCD/SETS/releases) page. Once downloaded this has to be decompressed and placed in into the `.config/images` folder.
 ```
 SETS
  +- .config
@@ -18,7 +18,7 @@ SETS
 ```
 
 ### Executable for Windows
-Download the zipped app from the [release](https://github.com/STOCD/releases) page. Unzip it into a folder where you want your app to live. To speed up the image downloading process, obtain the images library as detailed above. Double-clicking `SETS.exe` will start the app.
+Download the zipped app from the [release](https://github.com/STOCD/SETS/releases) page. Unzip it into a folder where you want your app to live. To speed up the image downloading process, obtain the images library as detailed above. Double-clicking `SETS.exe` will start the app.
 
 You can create a desktop shortcut by rightclicking on `SETS.exe` and clicking on "Create shortcut" in the context menu. Then move the created shortcut to your desktop. To create a start menu entry, open the start menu folder by rightclicking on an arbitrary app in your start menu and clicking on "Open file location". Then move the created shortcut to the folder that opened.
 

--- a/src/buildupdater.py
+++ b/src/buildupdater.py
@@ -252,6 +252,8 @@ def get_variable_slot_counts(self, ship_data: dict):
         tac_consoles = ship_data['consolestac']
         if 'Innovation Effects' in ship_data['abilities']:
             uni_consoles += 1
+        elif ship_data['name'] == 'Federation Intel Holoship':
+            uni_consoles += 1
         if '-X2' in self.build['space']['tier']:
             uni_consoles += 2
             starship_traits += 2


### PR DESCRIPTION
The Intel Holoship has a built-in Universal Console slot that is not reflected in its `consolesuni` cargo field (which stays at 0). Without this fix the slot is never shown in the UI.

Add an `elif` branch alongside the existing Innovation Effects check so the extra slot is counted when the ship is an Intel Holoship.