### PR TITLE
fix: add missing playable species to Federation and Klingon faction sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Builds can be exported to a PNG or JSON file that can be opened by another perso
 
 ## Installation
 ### Images library
-All installation methods require an images library containing the game icons. The app will download these automatically, but as this takes a very long time, it is recommended to download the newest compressed image library from the [release](https://github.com/STOCD/releases) page. Once downloaded this has to be decompressed and placed in into the `.config/images` folder.
+All installation methods require an images library containing the game icons. The app will download these automatically, but as this takes a very long time, it is recommended to download the newest compressed image library from the [release](https://github.com/STOCD/SETS/releases) page. Once downloaded this has to be decompressed and placed in into the `.config/images` folder.
 ```
 SETS
  +- .config
@@ -18,7 +18,7 @@ SETS
 ```
 
 ### Executable for Windows
-Download the zipped app from the [release](https://github.com/STOCD/releases) page. Unzip it into a folder where you want your app to live. To speed up the image downloading process, obtain the images library as detailed above. Double-clicking `SETS.exe` will start the app.
+Download the zipped app from the [release](https://github.com/STOCD/SETS/releases) page. Unzip it into a folder where you want your app to live. To speed up the image downloading process, obtain the images library as detailed above. Double-clicking `SETS.exe` will start the app.
 
 You can create a desktop shortcut by rightclicking on `SETS.exe` and clicking on "Create shortcut" in the context menu. Then move the created shortcut to your desktop. To create a start menu entry, open the start menu folder by rightclicking on an arbitrary app in your start menu and clicking on "Open file location". Then move the created shortcut to the folder that opened.
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -81,11 +81,14 @@ FACTIONS = {'Federation', 'Klingon', 'Romulan', 'Dominion', 'TOS Federation', 'D
 
 SPECIES = {
     'Federation': {
-        'Human', 'Andorian', 'Bajoran', 'Benzite', 'Betazoid', 'Bolian', 'Ferengi', 'Pakled',
-        'Rigelian', 'Saurian', 'Tellarite', 'Trill', 'Joined Trill', 'Vulcan', 'Alien',
-        'Liberated Borg'
+        'Human', 'Andorian', 'Bajoran', 'Benzite', 'Betazoid', 'Bolian', 'Caitian', 'Ferengi',
+        'Pakled', 'Rigelian', 'Saurian', 'Talaxian', 'Tellarite', 'Trill', 'Joined Trill',
+        'Vulcan', 'Alien', 'Liberated Borg', 'Klingon'
     },
-    'Klingon': {'Klingon', 'Gorn', 'Lethean', 'Nausicaan', 'Orion', 'Alien', 'Liberated Borg'},
+    'Klingon': {
+        'Klingon', 'Gorn', 'Lethean', 'Nausicaan', 'Orion', 'Alien', 'Liberated Borg',
+        'Ferasan', 'Talaxian'
+    },
     'Romulan': {'Romulan', 'Reman', 'Alien', 'Liberated Borg'},
     'Dominion': {"Jem'Hadar", "Jem'Hadar Vanguard"},
     'TOS Federation': {'Human', 'Andorian', 'Tellarite', 'Vulcan'},


### PR DESCRIPTION
Federation: add Caitian, Talaxian, and Klingon (cross-faction unlocks available in-game).
Klingon: add Ferasan and Talaxian (both purchasable from the C-Store and fully playable in the KDF faction).

Without these entries the species selector silently ignores these characters, causing incorrect faction/species validation.