### PR TITLE
fix: IndexError in markdown export when BOFF station has no abilities

### DIFF
--- a/src/export.py
+++ b/src/export.py
@@ -205,7 +205,7 @@ def get_build_markdown(self, environment: str, type_: str) -> str:
         boff_table = [['**Profession**', '**Power**', '**Notes**']]
         for specs, station in zip(self.build['space']['boff_specs'], self.build['space']['boffs']):
             if any(specs):
-                station_name = BOFF_RANKS_MD[station.count(None)] + ' ' + specs[0]
+                station_name = BOFF_RANKS_MD[min(station.count(None), len(BOFF_RANKS_MD) - 1)] + ' ' + specs[0]
                 if specs[1] != '':
                     station_name += ' / ' + specs[1]
                 boff_table += md_boff_table(self, station, station_name)


### PR DESCRIPTION
## Summary

When a build has a bridge officer profession assigned but no abilities filled in, `station.count(None)` returns 4. `BOFF_RANKS_MD` is a 4-element tuple (indices 0–3), so index 4 raises `IndexError` and the markdown export crashes entirely.

Fix: clamp the index to `len(BOFF_RANKS_MD) - 1` so an empty station falls back to Ensign rank gracefully.

## Reproduction

1. Select any ship
2. Set a BOFF profession (e.g. Tactical) but leave all ability slots empty
3. Click Export → Space Build → `IndexError: tuple index out of range`

## Change

```diff
- station_name = BOFF_RANKS_MD[station.count(None)] + ' ' + specs[0]
+ station_name = BOFF_RANKS_MD[min(station.count(None), len(BOFF_RANKS_MD) - 1)] + ' ' + specs[0]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)