### PR TITLE
fix: splash hangs forever on "Loading Cargo Data" when a cargo download fails

### DIFF
--- a/src/cargomanager.py
+++ b/src/cargomanager.py
@@ -413,7 +413,13 @@ class CargoManager():
                         if cargo_data is not None:
                             store_json(cargo_data, cargo_file)
                             return cargo_data
-                # TODO what happens when both backups fail?
+                # Download failed and no usable backup exists (typical on a
+                # fresh install when the wiki/GitHub cache is unreachable).
+                # Raise so the caller surfaces a real error instead of silently
+                # returning None — which would crash with TypeError further up.
+                raise RuntimeError(
+                    f"Could not obtain cargo table '{filename}': download "
+                    f"failed and no backup is available.")
             else:
                 return self.get_cargo_data(filename, url, ignore_cache_age=True)
         else:

--- a/src/downloader.py
+++ b/src/downloader.py
@@ -2,7 +2,7 @@ from json import loads as json__loads, JSONDecodeError
 from os import getenv as os__getenv
 from pathlib import Path
 from requests import Session
-from requests.exceptions import Timeout
+from requests.exceptions import RequestException
 from time import time
 from threading import Thread
 from typing import Callable
@@ -93,7 +93,7 @@ class Downloader(QObject):
                 response.encoding = 'utf-8'
                 return json__loads(compensate_json(response.text))
             return None
-        except (Timeout, JSONDecodeError):
+        except (RequestException, JSONDecodeError, ValueError):
             return None
 
     def download_cargo_table(self, url: str, file_name: str) -> dict | list | None:

--- a/src/widgets.py
+++ b/src/widgets.py
@@ -296,6 +296,7 @@ class Thread(QThread):
     """
     result: Signal = Signal(object)
     done: Signal = Signal()
+    error: Signal = Signal(object)
 
     def __init__(self, target: Callable, args: tuple = (), kwargs: dict[str] = {}):
         super().__init__()
@@ -318,9 +319,19 @@ class Thread(QThread):
     def run(self):
         """
         This function will be executed in a separate thread.
+
+        `done` is always emitted, even if the target raises, so callers waiting
+        on it (e.g. the splash screen) are never left hanging. Exceptions are
+        re-emitted via `error` so they can be logged or surfaced in the UI.
         """
-        self.result.emit(self._target(*self._args, **self._kwargs))
-        self.done.emit()
+        try:
+            self.result.emit(self._target(*self._args, **self._kwargs))
+        except BaseException as exc:
+            import traceback
+            traceback.print_exc()
+            self.error.emit(exc)
+        finally:
+            self.done.emit()
 
 
 class ShipButton(QLabel):


### PR DESCRIPTION
## Summary

On a fresh install (and occasionally on updates), the splash screen gets stuck on **"Loading Cargo Data..."** with no error and no progress. Users have reported this on Discord — the workaround so far has been to hand-copy somebody else's `cargo/*.json` files, which masks the real bug.

The freeze is not a slow download. It's three small issues in the cargo loading path that combine into one silent hang.

## Root cause

1. **`CargoManager.get_cargo_data` can silently return `None`.**
   When the wiki download fails *and* the GitHub cache fallback fails *and* there are no local backup files (the situation on every fresh install), the function falls through the `# TODO what happens when both backups fail?` branch without a `return`. Callers like `cache_boff_data` then do `for boff_ability in boff_cargo:` and crash with `TypeError: 'NoneType' is not iterable`.

2. **`Downloader.fetch_json` only catches `Timeout` and `JSONDecodeError`.**
   Anything else `requests` can raise — `ConnectionError`, `SSLError`, `ChunkedEncodingError`, Cloudflare returning a 5xx with a malformed body, etc. — propagates straight up.

3. **`widgets.Thread.run` doesn't catch exceptions from its target.**
   `init_backend` runs inside this `QThread`. If the target raises (because of 1 or 2), `self.done.emit()` is never reached. `complete_app_init` is wired to `done`, so it never runs and the splash stays on "Loading Cargo Data..." forever, with no error in the UI.

The reason it tends to hit later cargo tables (boff abilities, doffs, modifiers) is just that those queries are larger/slower on the wiki and so more prone to timing out or being rate-limited. Once one fails, the whole splash freezes.

## Fix

Three minimal changes, one per file:

**`src/cargomanager.py`** — replace the TODO with a real error so the caller can surface it instead of crashing on `None`:

```diff
-                # TODO what happens when both backups fail?
+                # Download failed and no usable backup exists (typical on a
+                # fresh install when the wiki/GitHub cache is unreachable).
+                # Raise so the caller surfaces a real error instead of silently
+                # returning None — which would crash with TypeError further up.
+                raise RuntimeError(
+                    f"Could not obtain cargo table '{filename}': download "
+                    f"failed and no backup is available.")
```

**`src/downloader.py`** — widen the exception net to all `requests` failures:

```diff
-from requests.exceptions import Timeout
+from requests.exceptions import RequestException
...
-        except (Timeout, JSONDecodeError):
+        except (RequestException, JSONDecodeError, ValueError):
             return None
```

**`src/widgets.py`** — make `Thread` emit `done` even when the target raises, and add an `error` signal so failures can be surfaced:

```diff
     result: Signal = Signal(object)
     done: Signal = Signal()
+    error: Signal = Signal(object)
...
     @Slot()
     def run(self):
-        self.result.emit(self._target(*self._args, **self._kwargs))
-        self.done.emit()
+        try:
+            self.result.emit(self._target(*self._args, **self._kwargs))
+        except BaseException as exc:
+            import traceback
+            traceback.print_exc()
+            self.error.emit(exc)
+        finally:
+            self.done.emit()
```

## Verification

Used a small repro harness (not included in the PR) that drives each failure path without launching the GUI:

| # | Scenario | Before | After |
|---|----------|--------|-------|
| 1 | Fresh install, downloader returns `None`, no backups | `get_cargo_data` returns `None`, caller TypeErrors | `RuntimeError` with a clear message |
| 2 | `requests.Session.get` raises `ConnectionError` | exception propagates, thread dies | `fetch_json` returns `None` |
| 3 | `Thread` target raises | `done` never emitted, splash hangs | `done` emitted, traceback printed |

In real terms: after this change, a transient wiki/Cloudflare failure during cargo load still fails — but it fails *visibly* (traceback in stderr, `done` fires, app can move forward / show an error) instead of silently freezing the splash.

## Out of scope

- Surfacing the `Thread.error` signal in the splash UI / showing a user-facing message box. Worth doing as a follow-up, but kept separate so this change stays focused on the freeze itself.
- Retry/backoff for transient wiki failures.